### PR TITLE
Modification for running on Android

### DIFF
--- a/dvbcss/monotonic_time.py
+++ b/dvbcss/monotonic_time.py
@@ -250,8 +250,10 @@ def _Linux_init(raw=False):
 		CLOCK = CLOCK_MONOTONIC_RAW
 	else:
 		CLOCK = CLOCK_MONOTONIC
-	
-	librt = ctypes.CDLL('librt.so.1', use_errno=True)
+	try:
+		librt = ctypes.CDLL('librt.so.1', use_errno=True)
+	except OSError:
+		librt = ctypes.CDLL('libc.so', use_errno=True)
 	clock_gettime = librt.clock_gettime
 	clock_nanosleep = librt.clock_nanosleep
 


### PR DESCRIPTION
On Android librt isn't available, but the functionality is subsumed in libc. This mod loads libc if librt doesn't exist.

(And please note that this whole git thingy and branch names and repo names and all that doesn't fit my mercurial-shaped brain, so please check that I haven't done something silly which'll mess up your repo for all eternity:-)
