### PR TITLE
Fix for speed zero semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Latest
 
+* Bugfix: fixed semantics on `calcWhen()`, `toParenTicks()` and `toRootTicks()`
+  when clock speed is 0.`
 * ...
 
 ## 0.4.0 : Bugfixes and overhaul of clock object model (new-clock-model)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Latest
 
 * Bugfix: fixed semantics on `calcWhen()`, `toParenTicks()` and `toRootTicks()`
-  when clock speed is 0.`
+  when clock speed is 0.` ([32256b6](https://github.com/bbc/pydvbcss/commit/32256b6f94ce01466ab4645097672e58a00456cc))
 * ...
 
 ## 0.4.0 : Bugfixes and overhaul of clock object model (new-clock-model)

--- a/docs/clock.rst
+++ b/docs/clock.rst
@@ -17,6 +17,22 @@ Module: `dvbcss.clock`
    :noindex:
 
 
+.. _nan:
+
+Not a number (nan)
+------------------
+
+"Not a number" value of a `float <https://docs.python.org/2/library/functions.html#float>`_. Check if a value is NaN like this::
+
+    >>> import math
+    >>> math.isnan(nanValue)
+    True
+
+Converting tick values to a parent clock or to the root clock may result in this
+value being returned if one or more of the clocks involved has speed zero.
+
+    
+
 Functions
 ---------
 

--- a/docs/task-internals.rst
+++ b/docs/task-internals.rst
@@ -15,8 +15,13 @@ Sleep and callback methods cause a task objet to be queued. The scheduler picks 
 binds to the Clock so that it is notified of adjustments to the clock. When a task is added to the queue, the clock is queried to calculate
 the true time at which the tick count is expected to be reached by calling :func:`dvbcss.clock.ClockBase.calcWhen`
 
-If a clock is adjusted the affected tasks are marked as deprecated (but remain in the priority queue) and new tasks are scheduled with a
+If a clock is adjusted the affected tasks are marked as deprecated (but remain in the priority queue) and new tasks are rescheduled with a
 recalculated time.
+
+When one of the clocks involved has speed 0, then it may not be possible to calculate the time at which the task is to be scheduled. This
+happens when :func:`dvbcss.clock.ClockBase.calcWhen` returns :ref:`nan`. The task will not be immediately added to the priority queue,
+however it will be added later once the clock speed returns to a non-zero value. This happens automatically as part of the rescheduling
+process when a clock is adjusted.
 	
 
 Objects

--- a/dvbcss/task.py
+++ b/dvbcss/task.py
@@ -157,7 +157,8 @@ class _Scheduler(object):
             while not self.addQueue.empty():
                 clock, whenTicks, callBack, args, kwargs = self.addQueue.get_nowait()
                 task = _Task(clock, whenTicks, callBack, args, kwargs)
-                heapq.heappush(self.taskheap, (task.when, task))
+                if not math.isnan(task.when):
+                    heapq.heappush(self.taskheap, (task.when, task))
 
                 if clock not in self.clock_Tasks:
                     self.clock_Tasks[clock] = { task:True }
@@ -171,7 +172,8 @@ class _Scheduler(object):
                 tasksMap=self.clock_Tasks.get(clock, {})
                 for task in tasksMap.keys():
                     newTask=task.regenerateAndDeprecate()
-                    heapq.heappush(self.taskheap,(newTask.when, newTask))
+                    if not math.isnan(newtask.when):
+                        heapq.heappush(self.taskheap,(newTask.when, newTask))
                     tasksMap[newTask] = True
                     del tasksMap[task]
  

--- a/test/test_Clock.py
+++ b/test/test_Clock.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import unittest
+import math
 
 import _useDvbCssUninstalled  # Enable to run when dvbcss not yet installed ... @UnusedImport
 
@@ -394,6 +395,10 @@ class Test_CorrelatedClock(unittest.TestCase):
         c = CorrelatedClock(b, 1000, correlation=Correlation(50,300))
         self.assertAlmostEqual(c.toParentTicks(400), 50 + (400-300)*2000, places=5 )
         
+        c = CorrelatedClock(b, 1000, correlation=Correlation(50,300), speed=0)
+        self.assertEquals(c.toParentTicks(300), 50)
+        self.assertTrue(math.isnan(c.toParentTicks(400)))
+        
     def test_fromParentTicks(self):
         mockTime = self.mockTime
 
@@ -403,6 +408,10 @@ class Test_CorrelatedClock(unittest.TestCase):
         
         c = CorrelatedClock(b, 1000, correlation=Correlation(50,300))
         self.assertAlmostEqual(c.fromParentTicks(50 + (400-300)*2000), 400, places=5 )
+        
+        c = CorrelatedClock(b, 1000, correlation=Correlation(50,300), speed=0)
+        self.assertEquals(c.fromParentTicks(50), 300)
+        self.assertEquals(c.fromParentTicks(100), 300)
       
     def test_getParent(self):
         b = self.newSysClock()


### PR DESCRIPTION
Fixes semantics of clock object when converting to parent time or root time.